### PR TITLE
Add GenBank export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Exporting Constructs to GenBank
+
+From the Final Construct panel you can download a GenBank file describing your assembled sequence.
+Click **Export GenBank** to save a `.gb` file. An example output begins like:
+
+```text
+LOCUS       Example            120 bp    DNA
+DEFINITION  Synthetic construct example.
+FEATURES             Location/Qualifiers
+     misc_feature    1..60
+                     /label="Module1"
+ORIGIN
+        1 atgcatgcat gcatgcatgc atgcatgcat gcatgcatgc atgcatgcat gcatgcatgc
+```

--- a/src/components/design-lab/final-construct.tsx
+++ b/src/components/design-lab/final-construct.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import Tippy from '@tippyjs/react';
 import { Download, Eye, EyeOff } from "lucide-react"
+import { generateGenBank } from "@/lib/genbank"
 import { toast } from "sonner"
 
 import { ConstructItem, Module } from "@/lib/types"
@@ -110,6 +111,31 @@ export const FinalConstruct = ({ constructModules }: FinalConstructProps) => {
     toast.success("Construct exported successfully!")
   }
 
+  const handleExportGenBank = () => {
+    if (modules.length === 0) {
+      toast.error("No modules to export")
+      return
+    }
+
+    const metadata = {
+      locus: constructName || 'CONSTRUCT',
+      definition: generatePredictedFunction(),
+      source: promoter,
+      organism: 'synthetic construct'
+    }
+
+    const gb = generateGenBank(generateAnnotatedSequence(), metadata)
+    const blob = new Blob([gb], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${constructName || 'construct'}.gb`
+    a.click()
+    URL.revokeObjectURL(url)
+
+    toast.success("GenBank file exported successfully!")
+  }
+
   return (
     <Card className="p-6">
       <div className="flex items-center justify-between mb-4">
@@ -126,6 +152,10 @@ export const FinalConstruct = ({ constructModules }: FinalConstructProps) => {
           <Button size="sm" onClick={handleExport}>
             <Download className="h-4 w-4 mr-2" />
             Export
+          </Button>
+          <Button size="sm" onClick={handleExportGenBank}>
+            <Download className="h-4 w-4 mr-2" />
+            Export GenBank
           </Button>
         </div>
       </div>

--- a/src/lib/genbank.ts
+++ b/src/lib/genbank.ts
@@ -1,0 +1,46 @@
+export interface AnnotatedSegment {
+  name: string;
+  sequence: string;
+  type: 'module' | 'linker' | 'hardcoded';
+}
+
+export interface GenBankInfo {
+  locus: string;
+  definition: string;
+  source: string;
+  organism?: string;
+  accession?: string;
+  version?: string;
+}
+
+export function generateGenBank(segments: AnnotatedSegment[], info: GenBankInfo): string {
+  const sequence = segments.map(s => s.sequence).join('').toUpperCase();
+  const length = sequence.length;
+
+  const locus = `LOCUS       ${info.locus.padEnd(16)}${String(length).padStart(11)} bp    DNA`;
+  const definition = `DEFINITION  ${info.definition}`;
+  const accession = `ACCESSION   ${info.accession ?? ''}`.trimEnd();
+  const version = `VERSION     ${info.version ?? ''}`.trimEnd();
+  const source = `SOURCE      ${info.source}`;
+  const organism = `  ORGANISM  ${info.organism ?? 'synthetic construct'}`;
+
+  let features = 'FEATURES             Location/Qualifiers\n';
+  let pos = 1;
+  for (const seg of segments) {
+    const start = pos;
+    const end = pos + seg.sequence.length - 1;
+    features += `     misc_feature    ${start}..${end}\n                     /label="${seg.name}"\n`;
+    pos = end + 1;
+  }
+
+  let origin = 'ORIGIN\n';
+  for (let i = 0; i < sequence.length; i += 60) {
+    const chunk = sequence.slice(i, i + 60).toLowerCase();
+    const spaced = chunk.match(/.{1,10}/g)?.join(' ') ?? '';
+    const lineNum = String(i + 1).padStart(9);
+    origin += `${lineNum} ${spaced}\n`;
+  }
+  origin += '//';
+
+  return [locus, definition, accession, version, source, organism, '', features, origin].join('\n');
+}


### PR DESCRIPTION
## Summary
- add a GenBank utility for generating files from annotated segments
- export GenBank format from the final construct panel
- document how to export to GenBank

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d3c3a8f948332851c85de50041623